### PR TITLE
summary and local bindings both have to be on first line

### DIFF
--- a/ghci-completion.el
+++ b/ghci-completion.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t; -*-
-;;; ghci-completion.el --- Completion for GHCi commands in inferior-haskell buffers
+;;; ghci-completion.el --- Completion for GHCi commands in inferior-haskell buffers -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012 Oleksandr Manzyuk <manzyuk@gmail.com>
 


### PR DESCRIPTION
If the summary isn't on the first line then lm-summary from builtin library lisp-mnt.el fails to extract the summary.

Do it like they do it in Emacs.
