### PR TITLE
Explicitly require emacs 24, and tidy up package description

### DIFF
--- a/ghci-completion.el
+++ b/ghci-completion.el
@@ -1,10 +1,11 @@
-;;; ghci-completion.el --- Completion for GHCi commands in inferior-haskell buffers -*- lexical-binding: t; -*-
+;;; ghci-completion.el --- Completion for GHCi commands in inferior-haskell buffers
 
 ;; Copyright (C) 2012 Oleksandr Manzyuk <manzyuk@gmail.com>
 
 ;; Author: Oleksandr Manzyuk <manzyuk@gmail.com>
 ;; Version: 0.1.3
 ;; Keywords: convenience
+;; Package-Requires: ((emacs "24.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -65,6 +66,10 @@
 ;;   able to generate the list of all GHC flags programmatically.
 
 ;;; Code:
+
+;; Local Variables:
+;; lexical-binding: t
+;; End:
 
 (eval-when-compile (require 'cl))
 (require 'comint)


### PR DESCRIPTION
I've just added a `ghc-completion` recipe to MELPA -- thanks for this useful package!

This commit adds an explicit package dependency upon Emacs 24 (see js2-mode for another example of this), and moves the lexical-bindings variable clause out of the package description, which prevents it from showing up in `package-list-packages`.

-Steve
