### PR TITLE
Remove eval-when-compile for using cl function

### DIFF
--- a/ghci-completion.el
+++ b/ghci-completion.el
@@ -5,7 +5,7 @@
 ;; Author: Oleksandr Manzyuk <manzyuk@gmail.com>
 ;; Version: 0.1.3
 ;; Keywords: convenience
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -67,7 +67,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 (require 'comint)
 (require 'pcomplete)
 
@@ -129,7 +129,7 @@
       (let ((beg (match-beginning 1))
             (end (match-end 1))
             (completions
-             (remove-if-not
+             (cl-remove-if-not
               (lambda (candidate)
                 (string-prefix-p command candidate))
               ghci-completion-commands)))
@@ -164,13 +164,13 @@ packages in both the global and user databases."
            "ghc-pkg" nil (current-buffer) nil "dump"
            ghci-completion-ghc-pkg-additional-args)
     (goto-char (point-min))
-    (loop while (re-search-forward
-                 (concat "exposed: True\n"
-                         "exposed-modules:"
-                         "\\(\\(?:.*\n?\\)*?\\)"
-                         "hidden-modules")
-                 nil t)
-          nconc (split-string (match-string 1) "[\s\n]+" t))))
+    (cl-loop while (re-search-forward
+                    (concat "exposed: True\n"
+                            "exposed-modules:"
+                            "\\(\\(?:.*\n?\\)*?\\)"
+                            "hidden-modules")
+                    nil t)
+             nconc (split-string (match-string 1) "[\s\n]+" t))))
 
 (defvar ghci-completion-language-options nil
   "The list of supported language extensions.")


### PR DESCRIPTION
eval-when-compile should not be used if a package uses only its macros.
And switch to cl-lib.

There are following byte-compile warnings about this.

```
In ghci-completion-command-completion:                                                 
ghci-completion.el:135:15:Warning: function `remove-if-not' from cl package            
    called at runtime                                                                  

In end of data:                                                                        
ghci-completion.el:433:1:Warning: the function `remove-if-not' might not be            
    defined at runtime.
```
